### PR TITLE
missing module exports fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -149,3 +149,5 @@ Log2gelf.prototype.log = function (level, msg, meta, callback) {
     this.send(gelfMsg);
     callback(null, true);
 };
+
+module.exports = Log2gelf;


### PR DESCRIPTION
module.exports is missing from index.js and could not get log2gelf to work without it.