### PR TITLE
Reconnect tcp on error or close

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ logger.transports.log2gelf.end();
 * `host`: The GELF server address (default: 127.0.0.1)
 * `port`: The GELF server port (default: 12201)
 * `protocol`: Protocol used to send data (`tcp`, `tls` [TCP over TLS], `http` or `https`). (default: tcp)
+* `reconnect`: Number of tcp reconnect attempts (default 0, 0 for none, -1 for infinite)
+* `wait`: Milliseconds to wait between reconnect attempts (default 1000)
 * `level`: Level of messages this transport should log. See [winston levels](https://github.com/winstonjs/winston#logging-levels) (default: info)
 * `silent`: Boolean flag indicating whether to suppress output. (default: false)
 * `handleExceptions`: Boolean flag, whenever to handle uncaught exceptions. (default: false)

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ function levelToInt(level) {
  * open a TCP socket and send logs to Gelf server
  * @param {string} msg – JSON stringified GELF msg
  */
-const sendTCPGelf = function (host, port, tls) {
+const sendTCPGelf = function (host, port, tls, reconnect, wait) {
     const options = {
         host,
         port,
@@ -39,8 +39,11 @@ const sendTCPGelf = function (host, port, tls) {
     if (tls) clientType = secNet;
     else clientType = net;
 
-    const client = clientType.connect(options, () => {
-        // console.log('Connected to Graylog server');
+    const client = clientType.connect(options);
+
+    client.on('connect', () => {
+        console.log('Connected to Graylog server');
+        client.reconnect = 0;
     });
 
     client.on('end', () => {
@@ -49,6 +52,16 @@ const sendTCPGelf = function (host, port, tls) {
 
     client.on('error', (err) => {
         console.error('Error connecting to Graylog:', err.message);
+        client.reconnect = client.reconnect + 1 || 0;
+    });
+
+    client.on('close', () => {
+        if (!client.ended && (reconnect == -1 || client.reconnect < reconnect)) {
+            client.timeout_id = setTimeout(() => {
+                client.timeout_id = null;
+                client.connect(options);
+            }, wait);
+        }
     });
 
     return {
@@ -56,6 +69,10 @@ const sendTCPGelf = function (host, port, tls) {
             client.write(`${msg}\0`);
         },
         end() {
+            if (client.timeout_id) {
+                clearTimeout(client.timeout_id);
+            }
+            client.ended = true;
             client.end();
         }
     };
@@ -104,6 +121,8 @@ const Log2gelf = winston.transports.Log2gelf = function (options) {
     this.host = options.host || '127.0.0.1';
     this.port = options.port || 12201;
     this.protocol = options.protocol || 'tcp';
+    this.reconnect = options.reconnect || '0';
+    this.wait = options.wait || 1000;
     this.service = options.service || 'nodejs';
     this.level = options.level || 'info';
     this.silent = options.silent || false;
@@ -118,13 +137,13 @@ const Log2gelf = winston.transports.Log2gelf = function (options) {
 
     // set protocol to use
     if (this.protocol === 'tcp') {
-        const tcpGelf = sendTCPGelf(this.host, this.port, false);
+        const tcpGelf = sendTCPGelf(this.host, this.port, false, this.reconnect, this.wait);
         this.send = tcpGelf.send;
         this.end = tcpGelf.end;
     }
 
     else if (this.protocol === 'tls') {
-        const tcpGelf = sendTCPGelf(this.host, this.port, true);
+        const tcpGelf = sendTCPGelf(this.host, this.port, true, this.reconnect, this.wait);
         this.send = tcpGelf.send;
         this.end = tcpGelf.end;
     }


### PR DESCRIPTION
Hello,

I needed my app to reconnect in case the graylog server is restarted or the app starts before graylog (happens with docker). Feel free to modify as you need.
This fixes issue #8 
