### PR TITLE
Allow millisecond precision on payload timestamp

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ class Log2gelf extends Transport {
         });
 
         const payload = {
-            timestamp: Math.floor(Date.now() / 1000),
+            timestamp: Date.now() / 1000,
             level: this.levelToInt(info.level),
             host: this.hostname,
             short_message: msg,


### PR DESCRIPTION
Tested against Graylog 2.4.6 server
Prior to change all message timestamps had 000 for milliseconds
After change messages had millisecond precision