### PR TITLE
Make socket options configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ logger.end = log2gelf.end;
 * `host`: The GELF server address (default: 127.0.0.1)
 * `port`: The GELF server port (default: 12201)
 * `protocol`: Protocol used to send data (`tcp`, `tls` [TCP over TLS], `http` or `https`). (default: tcp)
+* `protocolOptions`: Socket connect options. See [`net.socket.connect`](https://nodejs.org/api/net.html#net_socket_connect_options_connectlistener) or [`tls.connect`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback) for available options.
 * `reconnect`: Number of tcp reconnect attempts (default 0, 0 for none, -1 for infinite)
 * `wait`: Milliseconds to wait between reconnect attempts (default 1000)
 * `level`: Level of messages this transport should log. See [winston levels](https://github.com/winstonjs/winston#logging-levels) (default: info)

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ class Log2gelf extends Transport {
         this.silent = options.silent || false;
         this.environment = options.environment || 'development';
         this.release = options.release;
+        this.protocolOptions = options.protocolOptions || {};
         this.customPayload = {};
 
         Object.keys(options).forEach((key) => {
@@ -61,11 +62,11 @@ class Log2gelf extends Transport {
      * @return { Function } logger – logger(JSONlogs)
      */
     sendTCPGelf() {
-        const options = {
+        const options = Object.assign({}, this.protocolOptions, {
             host: this.host,
             port: this.port,
             rejectUnauthorized: false
-        };
+        });
 
         // whether or not tls is required
         let clientType;


### PR DESCRIPTION
If I want to use self-signed certificates and I need to set up socket options. This PR introduces a new option `protocolOptions`.

I've prepared the same improvement for `winston-syslog` transport here: https://github.com/winstonjs/winston-syslog/pull/116
