### PR TITLE
Fix HTTP transport content type

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ class Log2gelf extends Transport {
 
         return (msg) => {
             options.headers = {
-                'Content-Type': 'application/x-www-form-urlencoded',
+                'Content-Type': 'application/json',
                 'Content-Length': Buffer.byteLength(msg)
             };
 


### PR DESCRIPTION
The `Content-Type` sent with the HTTP(S) transport was `application/x-www-form-urlencoded`. Graylog expects JSON via the HTTP input, and the payload was already JSON, so this PR changes the content type to `application/json`.