### PR TITLE
Add option to pass pathname to HTTP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ logger.end = log2gelf.end;
 * `protocolOptions`: Socket connect options. See [`net.socket.connect`](https://nodejs.org/api/net.html#net_socket_connect_options_connectlistener) or [`tls.connect`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback) for available options.
 * `reconnect`: Number of tcp reconnect attempts (default 0, 0 for none, -1 for infinite)
 * `wait`: Milliseconds to wait between reconnect attempts (default 1000)
+* `path`: Pathname used when `protocol` is either `http` or `https`. Useful if Graylog's HTTP input is running behind a reverse proxy. (default: `/gelf`).
 * `level`: Level of messages this transport should log. See [winston levels](https://github.com/winstonjs/winston#logging-levels) (default: info)
 * `silent`: Boolean flag indicating whether to suppress output. (default: false)
 * `handleExceptions`: Boolean flag, whether to handle uncaught exceptions. (default: false)

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ class Log2gelf extends Transport {
         this.hostname = options.hostname || os.hostname();
         this.host = options.host || '127.0.0.1';
         this.port = options.port || 12201;
+        this.path = options.path;
         this.protocol = options.protocol || 'tcp';
         this.reconnect = options.reconnect || '0';
         this.wait = options.wait || 1000;
@@ -120,7 +121,7 @@ class Log2gelf extends Transport {
         const options = {
             port: this.port,
             hostname: this.host,
-            path: '/gelf',
+            path: this.path || '/gelf',
             method: 'POST',
             rejectUnauthorized: false
         };


### PR DESCRIPTION
This PR lets the user change the default HTTP path (`/gelf`) when the HTTP transport is used. This is useful when Graylog's HTTP input is behind a reverse proxy, for example when it's running at `domain.com/graylog-input/` which means that the path needed is `domain.com/graylog-input/gelf`.

This change does not change the default behavior.