### PR TITLE
Add ability to override defaults with protocolOptions, merge protocolOptions also when using HTTP transports

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,6 @@ logger.end = log2gelf.end;
 * `port`: The GELF server port (default: 12201)
 * `protocol`: Protocol used to send data (`tcp`, `tls` [TCP over TLS], `http` or `https`). (default: tcp)
 * `protocolOptions`: Socket connect options. See [`net.socket.connect`](https://nodejs.org/api/net.html#net_socket_connect_options_connectlistener) or [`tls.connect`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback) for available options.
-* `reconnect`: Number of tcp reconnect attempts (default 0, 0 for none, -1 for infinite)
-* `wait`: Milliseconds to wait between reconnect attempts (default 1000)
 * `level`: Level of messages this transport should log. See [winston levels](https://github.com/winstonjs/winston#logging-levels) (default: info)
 * `silent`: Boolean flag indicating whether to suppress output. (default: false)
 * `handleExceptions`: Boolean flag, whether to handle uncaught exceptions. (default: false)
@@ -77,6 +75,24 @@ logger.end = log2gelf.end;
 * `environment`: the environment on which your service is running. (default: development)
 * `release`: the version of your service (e.g. 1.0.0).
 * `_foo`: any underscore-prefixed custom option will be passed as is to the server.
+
+### Protocol-specific options
+
+#### `tcp` and `tls`
+
+* `reconnect`: Number of tcp reconnect attempts (default 0, 0 for none, -1 for infinite)
+* `wait`: Milliseconds to wait between reconnect attempts (default 1000)
+
+### Overriding connection and request options 
+
+TCP connection and HTTP request specific options can be passed via `protocolOptions`. These options are passed to the function making the request:
+
+| Protocol | API                                                                                                  |
+|----------|------------------------------------------------------------------------------------------------------|
+| `tcp`    | [`net.socket.connect()`](https://nodejs.org/api/net.html#net_socket_connect_options_connectlistener) |
+| `tls`    | [`tls.connect()`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback)                  |
+| `http`   | [`http.request()`](https://nodejs.org/api/http.html#http_http_request_options_callback)              |
+| `https`  | [`https.request()`](https://nodejs.org/api/https.html#https_https_request_options_callback)          |
 
 ## Contributing
 There's sure room for improvement, so feel free to hack around and submit PRs!

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ logger.end = log2gelf.end;
 
 ### Overriding connection and request options
 
-_**API change**: prior to version `2.3.0`, the `host`, `port` and `rejectUnauthorized` options were not overrideable by `protocolOptions`!_
+_**API change**: prior to version `2.3.0`, the `host`, `port` and `rejectUnauthorized` options were not overrideable by `protocolOptions`. They were also previously not applied when using the `http` or `https` protocol!_
 
 TCP connection and HTTP request specific options can be passed via `protocolOptions`.
 These options override the default options (for example, `host` and `port`), and are passed to the function making the request:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ logger.end = log2gelf.end;
 * `host`: The GELF server address (default: 127.0.0.1)
 * `port`: The GELF server port (default: 12201)
 * `protocol`: Protocol used to send data (`tcp`, `tls` [TCP over TLS], `http` or `https`). (default: tcp)
-* `protocolOptions`: Socket connect options. See [`net.socket.connect`](https://nodejs.org/api/net.html#net_socket_connect_options_connectlistener) or [`tls.connect`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback) for available options.
+* `protocolOptions`: See [_Overriding connection and request options_](#overriding-connection-and-request-options).
 * `level`: Level of messages this transport should log. See [winston levels](https://github.com/winstonjs/winston#logging-levels) (default: info)
 * `silent`: Boolean flag indicating whether to suppress output. (default: false)
 * `handleExceptions`: Boolean flag, whether to handle uncaught exceptions. (default: false)
@@ -83,9 +83,12 @@ logger.end = log2gelf.end;
 * `reconnect`: Number of tcp reconnect attempts (default 0, 0 for none, -1 for infinite)
 * `wait`: Milliseconds to wait between reconnect attempts (default 1000)
 
-### Overriding connection and request options 
+### Overriding connection and request options
 
-TCP connection and HTTP request specific options can be passed via `protocolOptions`. These options are passed to the function making the request:
+_**API change**: prior to version `2.3.0`, the `host`, `port` and `rejectUnauthorized` options were not overrideable by `protocolOptions`!_
+
+TCP connection and HTTP request specific options can be passed via `protocolOptions`.
+These options override the default options (for example, `host` and `port`), and are passed to the function making the request:
 
 | Protocol | API                                                                                                  |
 |----------|------------------------------------------------------------------------------------------------------|
@@ -93,6 +96,25 @@ TCP connection and HTTP request specific options can be passed via `protocolOpti
 | `tls`    | [`tls.connect()`](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback)                  |
 | `http`   | [`http.request()`](https://nodejs.org/api/http.html#http_http_request_options_callback)              |
 | `https`  | [`https.request()`](https://nodejs.org/api/https.html#https_https_request_options_callback)          |
+
+This can be used to, for example with the `http` and `https` protocol, include custom headers or change the path if the GELF HTTP input is behind a reverse proxy:
+
+```js
+new Log2gelf({
+    level: 'error',
+    host: '192.168.0.15',
+    port: 12202,
+    protocol: 'http',
+    protocolOptions: {
+        path: '/gelf-input/gelf',
+        headers: {
+            'X-API-Key': 'secret-key'
+        }
+    }
+})
+```
+
+**Note**: When using the `http` or `https` protocol, the `Content-Length` header is overwritten by `winston-log2gelf` to match the byte length of the message being sent and thus cannot be overridden with `protocolOptions`.
 
 ## Contributing
 There's sure room for improvement, so feel free to hack around and submit PRs!

--- a/index.js
+++ b/index.js
@@ -117,16 +117,23 @@ class Log2gelf extends Transport {
      * @return { Function } logger – logger(JSONlogs)
      */
     sendHTTPGelf() {
-        const options = Object.assign({
-            port: this.port,
-            hostname: this.host,
-            path: '/gelf',
-            method: 'POST',
-            rejectUnauthorized: false,
-            headers: {
-                'Content-Type': 'application/json'
+        const headers = Object.assign({
+            'Content-Type': 'application/json'
+        }, this.protocolOptions && this.protocolOptions.headers);
+
+        const options = Object.assign(
+            {
+                port: this.port,
+                hostname: this.host,
+                path: '/gelf',
+                method: 'POST',
+                rejectUnauthorized: false
+            },
+            this.protocolOptions,
+            {
+                headers
             }
-        }, this.protocolOptions);
+        );
 
         let clientType;
         if (this.protocol === 'https') clientType = https;

--- a/index.js
+++ b/index.js
@@ -122,7 +122,10 @@ class Log2gelf extends Transport {
             hostname: this.host,
             path: '/gelf',
             method: 'POST',
-            rejectUnauthorized: false
+            rejectUnauthorized: false,
+            headers: {
+                'Content-Type': 'application/json'
+            }
         };
 
         let clientType;
@@ -130,10 +133,7 @@ class Log2gelf extends Transport {
         else clientType = http;
 
         return (msg) => {
-            options.headers = {
-                'Content-Type': 'application/json',
-                'Content-Length': Buffer.byteLength(msg)
-            };
+            options.headers['Content-Length'] = Buffer.byteLength(msg);
 
             const req = clientType.request(options, (res) => { // eslint-disable-line
                 // usefull for debug

--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ class Log2gelf extends Transport {
      * @return { Function } logger – logger(JSONlogs)
      */
     sendHTTPGelf() {
-        const options = {
+        const options = Object.assign({
             port: this.port,
             hostname: this.host,
             path: '/gelf',
@@ -126,7 +126,7 @@ class Log2gelf extends Transport {
             headers: {
                 'Content-Type': 'application/json'
             }
-        };
+        }, this.protocolOptions);
 
         let clientType;
         if (this.protocol === 'https') clientType = https;

--- a/index.js
+++ b/index.js
@@ -62,11 +62,11 @@ class Log2gelf extends Transport {
      * @return { Function } logger – logger(JSONlogs)
      */
     sendTCPGelf() {
-        const options = Object.assign({}, this.protocolOptions, {
+        const options = Object.assign({
             host: this.host,
             port: this.port,
             rejectUnauthorized: false
-        });
+        }, this.protocolOptions);
 
         // whether or not tls is required
         let clientType;


### PR DESCRIPTION
Previously, `protocolOptions` was only applied to the tcp and tls protocols, and the tcp client's options `host`, `port` and `rejectUnauthorized` could not be overridden. This PR expands `protocolOptions`'s behavior to also apply to the http and https protocols, and merges the `protocolOptions` on top of the default options.

This PR is thus a breaking change, if the user:
- Uses either the tcp or tls protocol and has set `protocolOptions.host`, `protocolOptions.port` or `protocolOptions.rejectUnauthorized`
    * These options now override the `host` and `port` options, and the default `rejectUnauthorized: false`
- Uses either the http or https protocol and has set `protocolOptions`
    * These options previously did not do anything, but do after these changes.